### PR TITLE
feat: 장바구니 기능 추가 및 주문하기 기능 추가 (redis, 카카오페이 api 연동)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ $RECYCLE.BIN/
 *.lock
 build/tmp
 .gitignore
+application-dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,3 @@ $RECYCLE.BIN/
 *.lock
 build/tmp
 .gitignore
-src/main/java/com/younggeun/delivery/global/config/CacheConfig.java
-src/main/java/com/younggeun/delivery/DeliveryApplication.java
-src/main/java/com/younggeun/delivery/user/domain/entity/Cart.java
-src/main/java/com/younggeun/delivery/user/domain/dto/CartDto.java

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,6 @@ $RECYCLE.BIN/
 .gradle/
 .idea/
 *.lock
-build/tmp
+build/
 .gitignore
 application-dev.yml

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
   - 해당 메뉴의 추가 메뉴만 삭제할 수 있다.
 
 - [ ] 주문
-  - POST /order
+  - POST /orderTable
   - 사용자는 주문할 수 있다. 요청 사항을 입력받는다. 가게의 최소 주문 금액보다 총 주문 금액이 작다면 주문 할 수 없다.
 
 - [ ] 결제
@@ -111,16 +111,16 @@
   - 결제가 승인되지 않는다면 해당 주문은 삭제된다.
 
 - [ ] 한달간 총 구매 금액 + 한달간 주문한 카테고리 별 주문 횟수 조회
-  - GET /order/month
+  - GET /orderTable/month
   - 사용자는 현재 달의 총 구매 금액, 한달간 주문한 카테고리 별 주문 횟수 조회을 조회할 수 있다.
 
 - [ ] 주문 내역 확인
-  - GET /order/list
+  - GET /orderTable/list
   - 사용자는 주문한 내역을 확인 할 수 있다.
   - 페이징 처리를 통해 한번에 10개씩 조회 할 수 있다.
   
 - [ ] 주문 내역 상세보기
-  - GET /order?order={orderId}
+  - GET /orderTable?orderTable={orderId}
   - 사용자는 선택한 주문 내역의 정보를 확인 할 수 있다.
 
 - [ ] 리뷰 작성하기
@@ -268,16 +268,16 @@
   - 사용자는 메뉴에 대한 추가 메뉴를 삭제할 수 있다.
 
 - [ ] 주문 조회
-  - GET /order/list
+  - GET /orderTable/list
   - 사용자는 현재 날짜의 주문을 조회할 수 있다. 최신 순으로 정렬된다.
   - 페이징 처리를 통해 최대 10개씩 조회 가능하다.
 
 - [ ] 주문 상세 조회
-  - GET /order/detail?order={orderId}
+  - GET /orderTable/detail?orderTable={orderId}
   - 사용자는 해당 주문을 상세 조회할 수 있다.
 
 - [ ] 배달 완료 처리
-  - PUT /order/delivery/{orderId}
+  - PUT /orderTable/delivery/{orderId}
   - 사용자는 해당 주문의 배달 완료 처리할 수 있다.
 
 - [ ] 영업 상태 변경(오픈 / 마감)

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build/resources/main/application.yml
+++ b/build/resources/main/application.yml
@@ -2,25 +2,14 @@ spring:
   application:
     name: Delivery
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/delivery
-    username: delivery
-    password: delivery
+  profiles:
+    group:
+      logging: dev, log
+    active: dev
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    defer-datasource-initialization: true
-
-  jwt:
-    secret: c3ByaW5nLWJvb3QtcHJvamVjdC1kZWxpdmVyeS1zZXJ2aWNlLWp3dC1zZWNyZXQta2V5Cgbg
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
+  config:
+    import:
+      - classpath:/yaml/application-dev.yml
 
 logging:
   level:
@@ -29,14 +18,12 @@ logging:
 
 
 
-store:
-  photo:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/photo/files
-    baseUrlPath: /files
-  profile:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/profile/files
-    baseUrlPath: /files
-menu:
-  photo:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/menu/photo/files
-    baseUrlPath: /files
+
+
+#kakaopay:
+#  admin-key: 92308f2141a289808ff6fba12e4fc0b1
+#  dev-key: DEV4C6A9948C4A0FC29A998B38A62EEA2024EE6F
+#  cid: 76D16B528843874742CD
+#  ready-url-dev: https://open-api.kakaopay.com/online/v1/payment/ready
+#  approve-url-dev: https://open-api.kakaopay.com/online/v1/payment/approve
+#  cancel-url-dev: https://open-api.kakaopay.com/online/v1/payment/cancel

--- a/build/resources/main/application.yml
+++ b/build/resources/main/application.yml
@@ -17,10 +17,17 @@ spring:
   jwt:
     secret: c3ByaW5nLWJvb3QtcHJvamVjdC1kZWxpdmVyeS1zZXJ2aWNlLWp3dC1zZWNyZXQta2V5Cgbg
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     root: INFO
     com.younggeun.delivery: DEBUG
+
+
 
 store:
   photo:

--- a/build/resources/main/application.yml
+++ b/build/resources/main/application.yml
@@ -15,15 +15,3 @@ logging:
   level:
     root: INFO
     com.younggeun.delivery: DEBUG
-
-
-
-
-
-#kakaopay:
-#  admin-key: 92308f2141a289808ff6fba12e4fc0b1
-#  dev-key: DEV4C6A9948C4A0FC29A998B38A62EEA2024EE6F
-#  cid: 76D16B528843874742CD
-#  ready-url-dev: https://open-api.kakaopay.com/online/v1/payment/ready
-#  approve-url-dev: https://open-api.kakaopay.com/online/v1/payment/approve
-#  cancel-url-dev: https://open-api.kakaopay.com/online/v1/payment/cancel

--- a/src/main/java/com/younggeun/delivery/global/config/CacheConfig.java
+++ b/src/main/java/com/younggeun/delivery/global/config/CacheConfig.java
@@ -1,0 +1,66 @@
+package com.younggeun.delivery.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
+
+    RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+    return RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(conf)
+        .build();
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+    return template;
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory(){
+
+    // Single 모드
+    RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+
+    // Cluster 모드
+    // RedisClusterConfiguration conf = new RedisClusterConfiguration();
+
+    conf.setHostName(host);
+    conf.setPort(port);
+
+    return new LettuceConnectionFactory(conf);
+  }
+
+}

--- a/src/main/java/com/younggeun/delivery/global/config/KakaoPayConfig.java
+++ b/src/main/java/com/younggeun/delivery/global/config/KakaoPayConfig.java
@@ -1,0 +1,48 @@
+package com.younggeun.delivery.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoPayConfig {
+  public static String adminKey;
+  public static String devKey;
+  public static String cid;
+  public static String readyUrlDev;
+  public static String approveUrlDev;
+
+  public static String cancelUrlDev;
+
+  @Value("${kakaopay.admin-key}")
+  public void setAdminKey(String adminKey) {
+    KakaoPayConfig.adminKey = adminKey;
+  }
+
+  @Value("${kakaopay.cid}")
+  public void setCid(String cid) {
+    KakaoPayConfig.cid = cid;
+  }
+
+  @Value("${kakaopay.dev-key}")
+  public void setDevKey(String devKey) {
+    KakaoPayConfig.devKey = devKey;
+  }
+
+  @Value("${kakaopay.ready-url-dev}")
+  public void setReadyUrlDev(String readyUrlDev) {
+    KakaoPayConfig.readyUrlDev = readyUrlDev;
+  }
+
+  @Value("${kakaopay.approve-url-dev}")
+  public void setApproveUrlDev(String approveUrlDev) {
+    KakaoPayConfig.approveUrlDev = approveUrlDev;
+  }
+
+  @Value("${kakaopay.cancel-url-dev}")
+  public void setCancelUrlDev(String cancelUrlDev) {
+    KakaoPayConfig.cancelUrlDev = cancelUrlDev;
+  }
+
+
+
+}

--- a/src/main/java/com/younggeun/delivery/global/config/KakaoPayConfig.java
+++ b/src/main/java/com/younggeun/delivery/global/config/KakaoPayConfig.java
@@ -1,48 +1,19 @@
 package com.younggeun.delivery.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "kakaopay")
 public class KakaoPayConfig {
-  public static String adminKey;
-  public static String devKey;
-  public static String cid;
-  public static String readyUrlDev;
-  public static String approveUrlDev;
-
-  public static String cancelUrlDev;
-
-  @Value("${kakaopay.admin-key}")
-  public void setAdminKey(String adminKey) {
-    KakaoPayConfig.adminKey = adminKey;
-  }
-
-  @Value("${kakaopay.cid}")
-  public void setCid(String cid) {
-    KakaoPayConfig.cid = cid;
-  }
-
-  @Value("${kakaopay.dev-key}")
-  public void setDevKey(String devKey) {
-    KakaoPayConfig.devKey = devKey;
-  }
-
-  @Value("${kakaopay.ready-url-dev}")
-  public void setReadyUrlDev(String readyUrlDev) {
-    KakaoPayConfig.readyUrlDev = readyUrlDev;
-  }
-
-  @Value("${kakaopay.approve-url-dev}")
-  public void setApproveUrlDev(String approveUrlDev) {
-    KakaoPayConfig.approveUrlDev = approveUrlDev;
-  }
-
-  @Value("${kakaopay.cancel-url-dev}")
-  public void setCancelUrlDev(String cancelUrlDev) {
-    KakaoPayConfig.cancelUrlDev = cancelUrlDev;
-  }
-
-
-
+  private String adminKey;
+  private String devKey;
+  private String cid;
+  private String readyUrlDev;
+  private String approveUrlDev;
+  private String cancelUrlDev;
 }

--- a/src/main/java/com/younggeun/delivery/global/exception/type/CommonErrorCode.java
+++ b/src/main/java/com/younggeun/delivery/global/exception/type/CommonErrorCode.java
@@ -14,7 +14,10 @@ public enum CommonErrorCode implements ErrorCode {
   PHOTO_NOT_FOUND(HttpStatus.BAD_REQUEST, "사진 저장에 실패했습니다."),
   NOT_ALLOW_EXCEPTION(HttpStatus.FORBIDDEN, "허가되지 않은 접근입니다."),
   CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 카테고리가 존재하지 않습니다."),
-  EXIST_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "해당 카테고리명이 이미 존재합니다."),;
+  EXIST_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "해당 카테고리명이 이미 존재합니다."),
+  SERIALIZING_CART_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "Error serializing cart."),
+  DESERIALIZING_CART_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "Error deserializing cart."),;
+
   private final HttpStatus httpStatus;
   private final String message;
 }

--- a/src/main/java/com/younggeun/delivery/global/exception/type/PayErrorCode.java
+++ b/src/main/java/com/younggeun/delivery/global/exception/type/PayErrorCode.java
@@ -1,0 +1,18 @@
+package com.younggeun.delivery.global.exception.type;
+
+import com.younggeun.delivery.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PayErrorCode implements ErrorCode {
+  KAKOPAY_CANCELED(HttpStatus.BAD_REQUEST, "카카오페이 결제를 취소했습니다."),
+  KAKAOPAY_FAILED(HttpStatus.BAD_REQUEST, "카카오페이 결제가 실패했습니다."),
+  ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 조회에 실패했습니다."),
+  LEAST_ORDER_COST(HttpStatus.BAD_REQUEST, "장바구니에 담긴 총 금액이 최소 주문 금액보다 작습니다."),;
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/src/main/java/com/younggeun/delivery/global/exception/type/StoreErrorCode.java
+++ b/src/main/java/com/younggeun/delivery/global/exception/type/StoreErrorCode.java
@@ -15,10 +15,14 @@ public enum StoreErrorCode implements ErrorCode {
   EXISTS_SEQUENCE_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 순번입니다."),
   CANNOT_DELETE_CATEGORY_CAUSE_EXIST_MENU_BY_CATEGORY_ID(HttpStatus.BAD_REQUEST, "해당 카테고리에 존재하는 메뉴가 있습니다. 해당 카테고리의 메뉴를 먼저 삭제해주세요."),
   MISMATCH_PARTNER_STORE(HttpStatus.BAD_REQUEST, "가게에 등록된 파트너와 로그인한 파트너가 일치하지 않습니다."),
+  MISMATCH_PARTNER_ORDER(HttpStatus.BAD_REQUEST, "주문에 등록된 파트너와 로그인한 파트너가 일치하지 않습니다."),
   EXIST_PHOTO_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 사진이 존재합니다."),
   MISMATCH_STORE_CATEGORY(HttpStatus.BAD_REQUEST, "해당 가게와 카테고리의 가게가 일치하지 않습니다."),
   MISMATCH_STORE_MENU(HttpStatus.BAD_REQUEST, "메뉴에 등록된 가게와 가게 ID가 일치하지 않습니다.."),
-  ALREADY_EXIST_SEQUENCE(HttpStatus.BAD_REQUEST, "해당 순서로 등록할 수 없습니다.");
+  ALREADY_EXIST_SEQUENCE(HttpStatus.BAD_REQUEST, "해당 순서로 등록할 수 없습니다."),
+  MENU_SOLD_OUT(HttpStatus.BAD_REQUEST, "장바구니에 담긴 메뉴가 품절되었습니다."),
+  STORE_NOT_OPENED(HttpStatus.BAD_REQUEST, "해당 가게가 영업 전입니다."),
+  CANNOT_CHANGE_ORDER(HttpStatus.BAD_REQUEST, "해당 주문의 상태를 변경할 수 없습니다."),;
   private final HttpStatus httpStatus;
   private final String message;
 

--- a/src/main/java/com/younggeun/delivery/global/exception/type/UserErrorCode.java
+++ b/src/main/java/com/younggeun/delivery/global/exception/type/UserErrorCode.java
@@ -17,11 +17,14 @@ public enum UserErrorCode implements ErrorCode {
   NO_MORE_ADDRESS_EXCEPTION(HttpStatus.BAD_REQUEST, "최대 5개까지의 주소를 저장할 수 있습니다. 다른 주소를 삭제하고 이용하세요."),
   ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 주소를 찾을 수 없습니다."),
   MISMATCH_USER_ADDRESS_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 주소 소유자가 일치하지 않습니다."),
+  NOT_DEFAULT_ADDRESS_ID(HttpStatus.BAD_REQUEST, "설정된 주소와 address id값이 다릅니다."),
   WISH_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 찜 id를 찾을 수 없습니다."),
   MISMATCH_USER_WISH_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 찜 소유자가 일치하지 않습니다."),
   DIFFERENT_STORE_IN_CART(HttpStatus.BAD_REQUEST, "같은 가게의 메뉴만 담을 수 있습니다."),
   CART_IS_EMPTY(HttpStatus.BAD_REQUEST, "장바구니가 비어있습니다."),
-  CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "카트 메뉴 번호와 일치하는 번호가 없습니다.");
+  CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "카트 메뉴 번호와 일치하는 번호가 없습니다."),
+  ORDER_MORE_THAN_ONE(HttpStatus.BAD_REQUEST, "장바구니에는 하나 이상의 수량을 담을 수 있습니다."),
+  MISMATCH_USER_ORDER(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 주문자와 일치하지 않습니다."),;
   private final HttpStatus httpStatus;
   private final String message;
 

--- a/src/main/java/com/younggeun/delivery/global/exception/type/UserErrorCode.java
+++ b/src/main/java/com/younggeun/delivery/global/exception/type/UserErrorCode.java
@@ -18,7 +18,10 @@ public enum UserErrorCode implements ErrorCode {
   ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 주소를 찾을 수 없습니다."),
   MISMATCH_USER_ADDRESS_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 주소 소유자가 일치하지 않습니다."),
   WISH_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 찜 id를 찾을 수 없습니다."),
-  MISMATCH_USER_WISH_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 찜 소유자가 일치하지 않습니다."),;
+  MISMATCH_USER_WISH_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인한 유저와 해당 찜 소유자가 일치하지 않습니다."),
+  DIFFERENT_STORE_IN_CART(HttpStatus.BAD_REQUEST, "같은 가게의 메뉴만 담을 수 있습니다."),
+  CART_IS_EMPTY(HttpStatus.BAD_REQUEST, "장바구니가 비어있습니다."),
+  CART_NOT_FOUND(HttpStatus.BAD_REQUEST, "카트 메뉴 번호와 일치하는 번호가 없습니다.");
   private final HttpStatus httpStatus;
   private final String message;
 

--- a/src/main/java/com/younggeun/delivery/partner/controller/PartnerOrderController.java
+++ b/src/main/java/com/younggeun/delivery/partner/controller/PartnerOrderController.java
@@ -1,0 +1,67 @@
+package com.younggeun.delivery.partner.controller;
+
+import com.younggeun.delivery.partner.service.PartnerOrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/partners/order")
+@RequiredArgsConstructor
+public class PartnerOrderController {
+  private final PartnerOrderService orderService;
+
+  @Operation(summary = "오늘 주문 목록 조회", description = "authentication")
+  @GetMapping("/{storeId}")
+  public ResponseEntity<?> getOrderList(Authentication authentication, Pageable pageable,
+      @PathVariable String storeId) {
+    var result = orderService.getPartnerOrderList(authentication, storeId, pageable);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "주문 상세 조회", description = "authentication")
+  @GetMapping("/{storeId}/{orderId}")
+  public ResponseEntity<?> getOrder(Authentication authentication,
+      @PathVariable String storeId, @PathVariable String orderId) {
+    var result = orderService.getPartnerOrder(authentication, storeId, orderId);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "주문 수락", description = "authentication")
+  @PutMapping("/{storeId}/{orderId}/accept")
+  public ResponseEntity<?> orderAccess(Authentication authentication,
+      @PathVariable String storeId, @PathVariable String orderId) {
+    var result = orderService.orderAccess(authentication, orderId, true);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "주문 거절", description = "authentication")
+  @PutMapping("/{storeId}/{orderId}/refuse")
+  public ResponseEntity<?> orderRefuse(Authentication authentication,
+      @PathVariable String storeId, @PathVariable String orderId) {
+    var result = orderService.orderAccess(authentication, orderId, false);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "배달 완료", description = "authentication")
+  @PutMapping("/{storeId}/{orderId}/complete")
+  public ResponseEntity<?> orderComplete(Authentication authentication,
+      @PathVariable String storeId, @PathVariable String orderId) {
+    var result = orderService.orderComplete(authentication, orderId);
+
+    return ResponseEntity.ok(result);
+  }
+}

--- a/src/main/java/com/younggeun/delivery/partner/domain/entity/Partner.java
+++ b/src/main/java/com/younggeun/delivery/partner/domain/entity/Partner.java
@@ -4,7 +4,6 @@ import com.younggeun.delivery.global.entity.BaseEntity;
 import com.younggeun.delivery.global.entity.RoleType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -45,7 +44,7 @@ public class Partner extends BaseEntity {
   private String address;
 
   @Column(nullable = false)
-  @Enumerated(EnumType.STRING)
+  @Enumerated
   private RoleType role;
 
   private LocalDateTime deletedAt;

--- a/src/main/java/com/younggeun/delivery/partner/service/PartnerOrderService.java
+++ b/src/main/java/com/younggeun/delivery/partner/service/PartnerOrderService.java
@@ -42,12 +42,12 @@ import org.springframework.stereotype.Service;
 @Service
 @AllArgsConstructor
 public class PartnerOrderService {
-  private PartnerRepository partnerRepository;
-  private StoreRepository storeRepository;
-  private OrderRepository orderRepository;
-  private MenuRepository menuRepository;
-  private AdditionalMenuRepository additionalMenuRepository;
-  private OrderHistoryRepository orderHistoryRepository;
+  private final PartnerRepository partnerRepository;
+  private final StoreRepository storeRepository;
+  private final OrderRepository orderRepository;
+  private final MenuRepository menuRepository;
+  private final AdditionalMenuRepository additionalMenuRepository;
+  private final OrderHistoryRepository orderHistoryRepository;
   public Page<OrderDto> getPartnerOrderList(
       Authentication authentication, String storeId, Pageable pageable) {
     Partner partner = partnerRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));

--- a/src/main/java/com/younggeun/delivery/partner/service/PartnerOrderService.java
+++ b/src/main/java/com/younggeun/delivery/partner/service/PartnerOrderService.java
@@ -1,0 +1,131 @@
+package com.younggeun.delivery.partner.service;
+
+import static com.younggeun.delivery.global.exception.type.PayErrorCode.ORDER_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.CANNOT_CHANGE_ORDER;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.MISMATCH_PARTNER_ORDER;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.MISMATCH_PARTNER_STORE;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.STORE_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.USER_NOT_FOUND_EXCEPTION;
+
+import com.younggeun.delivery.global.exception.RestApiException;
+import com.younggeun.delivery.partner.domain.PartnerRepository;
+import com.younggeun.delivery.partner.domain.entity.Partner;
+import com.younggeun.delivery.store.domain.AdditionalMenuRepository;
+import com.younggeun.delivery.store.domain.MenuRepository;
+import com.younggeun.delivery.store.domain.StoreRepository;
+import com.younggeun.delivery.store.domain.dto.AdditionalMenuDto;
+import com.younggeun.delivery.store.domain.dto.MenuDto;
+import com.younggeun.delivery.store.domain.dto.OrderDetailDto;
+import com.younggeun.delivery.store.domain.entity.Menu;
+import com.younggeun.delivery.store.domain.entity.Store;
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.OrderHistoryRepository;
+import com.younggeun.delivery.user.domain.OrderRepository;
+import com.younggeun.delivery.user.domain.dto.OrderDto;
+import com.younggeun.delivery.user.domain.entity.OrderHistory;
+import com.younggeun.delivery.user.domain.entity.OrderTable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class PartnerOrderService {
+  private PartnerRepository partnerRepository;
+  private StoreRepository storeRepository;
+  private OrderRepository orderRepository;
+  private MenuRepository menuRepository;
+  private AdditionalMenuRepository additionalMenuRepository;
+  private OrderHistoryRepository orderHistoryRepository;
+  public Page<OrderDto> getPartnerOrderList(
+      Authentication authentication, String storeId, Pageable pageable) {
+    Partner partner = partnerRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+    Store store = storeRepository.findById(Long.valueOf(storeId)).orElseThrow(() -> new RestApiException(STORE_NOT_FOUND));
+
+    if(partner.getPartnerId() != store.getPartner().getPartnerId()) {
+      throw new RestApiException(MISMATCH_PARTNER_STORE);
+    }
+
+    Page<OrderTable> orderTableList = orderRepository.findAllByStoreAndStatusGreaterThanAndUpdatedAtBetweenOrderByUpdatedAtDesc(store, OrderStatus.WITHDRAW,
+                                              LocalDateTime.of(LocalDate.now(), store.getOpenTime()),
+                                              LocalDateTime.of(store.getEndTime().isBefore(store.getOpenTime()) ?
+                                                  LocalDate.now().plusDays(1) : LocalDate.now(), store.getEndTime()), pageable);
+
+    return orderTableList.map(OrderDto::new);
+
+  }
+
+  public OrderDetailDto getPartnerOrder(Authentication authentication, String storeId, String orderId) {
+    Partner partner = partnerRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+    Store store = storeRepository.findById(Long.valueOf(storeId)).orElseThrow(() -> new RestApiException(STORE_NOT_FOUND));
+
+    if(partner.getPartnerId() != store.getPartner().getPartnerId()) {
+      throw new RestApiException(MISMATCH_PARTNER_STORE);
+    }
+
+    OrderTable orderTable = orderRepository.findById(Long.valueOf(orderId)).orElseThrow(() -> new RestApiException(ORDER_NOT_FOUND));
+    List<OrderHistory> orderHistoryList = orderHistoryRepository.findAllByOrderTableOrderId(orderTable.getOrderId());
+    List<Long> menuIdList = orderHistoryList.stream().map(OrderHistory::getMenu).filter(Objects::nonNull).map(Menu::getMenuId).distinct().toList();
+    List<MenuDto> menuList =  menuRepository.findAllByMenuIdIn(menuIdList).stream().map(MenuDto::new).toList();
+
+    Map<Long, ArrayList<AdditionalMenuDto>> additionalMenuMap = additionalMenuRepository.findAllByMenuMenuIdIn(menuIdList)
+        .stream().collect(Collectors.groupingBy(
+            additionalMenu -> additionalMenu.getMenu().getMenuId(),
+            Collectors.mapping(AdditionalMenuDto::new, Collectors.toCollection(ArrayList::new))
+        ));
+
+    menuList.forEach(menuDto -> menuDto.setAdditionalMenuList(additionalMenuMap.get(menuDto.getMenuId())));
+
+    return new OrderDetailDto(orderTable, menuList);
+
+  }
+
+  public OrderDto orderAccess(Authentication authentication, String orderId, boolean isAccess) {
+    Partner partner = partnerRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+
+    OrderTable orderTable = orderRepository.findById(Long.valueOf(orderId)).orElseThrow(() -> new RestApiException(ORDER_NOT_FOUND));
+
+    if(partner.getPartnerId() != orderTable.getStore().getPartner().getPartnerId()) {
+      throw new RestApiException(MISMATCH_PARTNER_ORDER);
+    }
+
+    if(orderTable.getStatus() != OrderStatus.PAYMENT) {
+      throw new RestApiException(CANNOT_CHANGE_ORDER);
+    }
+
+    orderTable.setStatus(isAccess ? OrderStatus.ACCEPT : OrderStatus.REFUSE);
+
+    return new OrderDto(orderRepository.save(orderTable));
+
+  }
+
+  public Object orderComplete(Authentication authentication, String orderId) {
+    Partner partner = partnerRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+
+    OrderTable orderTable = orderRepository.findById(Long.valueOf(orderId)).orElseThrow(() -> new RestApiException(ORDER_NOT_FOUND));
+
+    if(partner.getPartnerId() != orderTable.getStore().getPartner().getPartnerId()) {
+      throw new RestApiException(MISMATCH_PARTNER_ORDER);
+    }
+
+    if(orderTable.getStatus() != OrderStatus.ACCEPT) {
+      throw new RestApiException(CANNOT_CHANGE_ORDER);
+    }
+
+    orderTable.setStatus(OrderStatus.DELIVERY_COMPLETED);
+    orderTable.setDeliveryTime(LocalDateTime.now());
+
+    return new OrderDto(orderRepository.save(orderTable));
+  }
+}

--- a/src/main/java/com/younggeun/delivery/store/controller/StoreController.java
+++ b/src/main/java/com/younggeun/delivery/store/controller/StoreController.java
@@ -47,6 +47,22 @@ public class StoreController {
     return ResponseEntity.ok(result);
   }
 
+  @Operation(summary = "partner 상점 open", description = "storeId")
+  @PutMapping("/partners/store/{storeId}/open")
+  @PreAuthorize("hasRole('PARTNER')")
+  public ResponseEntity<?> openStore(Authentication authentication, @PathVariable String storeId) {
+    var result = storeService.changeOpened(authentication, storeId, true);
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "partner 상점 close", description = "storeId")
+  @PutMapping("/partners/store/{storeId}/close")
+  @PreAuthorize("hasRole('PARTNER')")
+  public ResponseEntity<?> closeStore(Authentication authentication, @PathVariable String storeId) {
+    var result = storeService.changeOpened(authentication, storeId, false);
+    return ResponseEntity.ok(result);
+  }
+
   @Operation(summary = "partner 상점 추가", description = "request")
   @PostMapping("/partners/store")
   @PreAuthorize("hasRole('PARTNER')")

--- a/src/main/java/com/younggeun/delivery/store/controller/StoreController.java
+++ b/src/main/java/com/younggeun/delivery/store/controller/StoreController.java
@@ -96,14 +96,8 @@ public class StoreController {
   @Operation(summary = "user 상점 전체 조회", description = "deliveryAddressDto, Pageable")
   @GetMapping("/users/store")
   @PreAuthorize("hasRole('USER')")
-  public ResponseEntity<?> selectAllStore(Authentication authentication,@RequestParam(name = "orderType", required = false) String orderType, @RequestBody DeliveryAddressDto deliveryAddressDto) {
-    OrderType type;
-
-    if(orderType == null) {
-      type = OrderType.star;
-    } else {
-      type = OrderType.valueOf(orderType);
-    }
+  public ResponseEntity<?> selectAllStore(Authentication authentication,@RequestParam(name = "orderType", required = false, defaultValue = "STAR") String orderType, @RequestBody DeliveryAddressDto deliveryAddressDto) {
+    OrderType type = OrderType.valueOf(orderType);
 
     var result = storeService.selectAllStoreByAddress(authentication,deliveryAddressDto, type);
     return ResponseEntity.ok(result);
@@ -113,14 +107,8 @@ public class StoreController {
   @GetMapping("/users/store/{categoryId}")
   @PreAuthorize("hasRole('USER')")
   public ResponseEntity<?> selectStoreByCategory(Authentication authentication,@RequestBody DeliveryAddressDto deliveryAddressDto,
-      @PathVariable String categoryId, @RequestParam(name = "orderType", required = false) String orderType) {
-    OrderType type;
-
-    if(orderType == null) {
-      type = OrderType.star;
-    } else {
-      type = OrderType.valueOf(orderType);
-    }
+      @PathVariable String categoryId, @RequestParam(name = "orderType", required = false, defaultValue = "STAR") String orderType) {
+    OrderType type = OrderType.valueOf(orderType);
 
     var result = storeService.selectStoreByCategory(authentication, Long.valueOf(categoryId), deliveryAddressDto, type);
     return ResponseEntity.ok(result);

--- a/src/main/java/com/younggeun/delivery/store/domain/AdditionalMenuRepository.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/AdditionalMenuRepository.java
@@ -4,15 +4,15 @@ import com.younggeun.delivery.store.domain.entity.AdditionalMenu;
 import com.younggeun.delivery.store.domain.entity.Menu;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface AdditionalMenuRepository extends JpaRepository<AdditionalMenu, Long> {
 
   boolean existsBySequenceAndMenu(int sequence, Menu menu);
 
-  @Query(nativeQuery = true, value = "SELECT * FROM additional_menu WHERE menu_id IN (:menuId)")
-  List<AdditionalMenu> findAllByMenuId(@Param("menuId") List<Long> menuIdList);
+  List<AdditionalMenu> findAllByMenuMenuIdIn(List<Long> menuIdList);
 
   List<AdditionalMenu> findAllByMenu(Menu menu);
+
+  List<AdditionalMenu> findAllByAdditionalMenuIdIn(List<Long> additionalIdList);
+
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/AdditionalMenuRepository.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/AdditionalMenuRepository.java
@@ -15,4 +15,5 @@ public interface AdditionalMenuRepository extends JpaRepository<AdditionalMenu, 
 
   List<AdditionalMenu> findAllByAdditionalMenuIdIn(List<Long> additionalIdList);
 
+  boolean existsByAdditionalMenuIdIn(List<Long> additionalMenuIdList);
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/MenuPhotoRepository.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/MenuPhotoRepository.java
@@ -5,7 +5,6 @@ import com.younggeun.delivery.store.domain.entity.MenuPhoto;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MenuPhotoRepository extends JpaRepository<MenuPhoto, Long> {
@@ -13,6 +12,5 @@ public interface MenuPhotoRepository extends JpaRepository<MenuPhoto, Long> {
 
   boolean existsByMenu(Menu menu);
 
-  @Query(nativeQuery = true, value = "SELECT * FROM menu_photo WHERE menu_id IN (:menuId)")
-  List<MenuPhoto> findAllByMenuId(@Param("menuId") List<Long> menuList);
+  List<MenuPhoto> findAllByMenuMenuIdIn(@Param("menuId") List<Long> menuList);
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/MenuRepository.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/MenuRepository.java
@@ -17,4 +17,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
   List<Menu> findAllMenusWithDetailsByStoreId(@Param("storeId") String storeId);
 
   boolean existsByMenuCategory(MenuCategory category);
+
+  boolean existsByMenuIdIn(List<Long> menuIdList);
+
+  List<Menu> findAllByMenuIdIn(List<Long> menuIdList);
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/MenuRepository.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/MenuRepository.java
@@ -8,8 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-  @Query(nativeQuery = true, value = "SELECT * FROM MENU WHERE category_id IN (:categoryId)")
-  List<Menu> findAllByMenuCategoryId(@Param("categoryId") List<Long> menuCategoryIdList);
+  List<Menu> findAllByMenuCategoryCategoryIdIn(List<Long> menuCategoryIdList);
 
   @Query("SELECT NEW com.younggeun.delivery.store.domain.dto.MenuDto(m.menuId, m.menuName, m.price, m.description, m.soldOutStatus, mc.categoryId) " +
       "FROM Menu m " +

--- a/src/main/java/com/younggeun/delivery/store/domain/dto/AdditionalMenuDto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/dto/AdditionalMenuDto.java
@@ -36,7 +36,7 @@ public class AdditionalMenuDto implements Comparable<AdditionalMenuDto> {
         .menuName(menuName)
         .sequence(sequence)
         .price(price)
-        .soldOutStatus(true)
+        .soldOutStatus(false)
         .menu(menu)
         .build();
   }

--- a/src/main/java/com/younggeun/delivery/store/domain/dto/MenuCategoryDto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/dto/MenuCategoryDto.java
@@ -17,6 +17,11 @@ public class MenuCategoryDto {
   private String name;
   private int sequence;
 
+  public MenuCategoryDto(MenuCategory menuCategory) {
+    name = menuCategory.getName();
+    sequence = menuCategory.getSequence();
+  }
+
   public MenuCategory toEntity(Store store) {
     return MenuCategory.builder()
         .name(name)

--- a/src/main/java/com/younggeun/delivery/store/domain/dto/MenuDto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/dto/MenuDto.java
@@ -22,7 +22,7 @@ public class MenuDto {
   private String description;
   private Long categoryId;
   private boolean soldOutStatus;
-  private MenuCategory menuCategory;
+  private MenuCategoryDto menuCategory;
 
   private PhotoDto menuPhoto;
   private List<AdditionalMenuDto> additionalMenuList;
@@ -42,7 +42,7 @@ public class MenuDto {
     this.price = menu.getPrice();
     this.description = menu.getDescription();
     this.soldOutStatus = menu.isSoldOutStatus();
-    this.menuCategory = menu.getMenuCategory();
+    this.menuCategory = new MenuCategoryDto(menu.getMenuCategory());
     this.categoryId = menu.getMenuCategory().getCategoryId();
   }
 

--- a/src/main/java/com/younggeun/delivery/store/domain/dto/OrderDetailDto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/dto/OrderDetailDto.java
@@ -1,0 +1,41 @@
+package com.younggeun.delivery.store.domain.dto;
+
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.entity.OrderTable;
+import com.younggeun.delivery.user.domain.type.PaymentType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderDetailDto {
+  private Long orderId;
+  private int totalPrice;
+  private OrderStatus status;
+  private String request;
+  private LocalDateTime deliveryTime;
+  private PaymentType paymentType;
+  private String address;
+  private Long storeId;
+  private List<MenuDto> menuDtoList;
+
+  public OrderDetailDto(OrderTable orderTable, List<MenuDto> menuList) {
+    this.menuDtoList = menuList;
+    this.orderId = orderTable.getOrderId();
+    this.totalPrice = orderTable.getTotalPrice();
+    this.status = orderTable.getStatus();
+    this.request = orderTable.getRequest();
+    this.deliveryTime = orderTable.getDeliveryTime();
+    this.paymentType = orderTable.getPaymentType();
+    this.address = orderTable.getAddress().getAddress1() + " " + orderTable.getAddress().getAddress2() + " " + orderTable.getAddress().getAddress3();
+    this.storeId = orderTable.getStore().getStoreId();
+  }
+}

--- a/src/main/java/com/younggeun/delivery/store/domain/dto/StoreDto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/dto/StoreDto.java
@@ -40,6 +40,7 @@ public class StoreDto {
   private boolean accessStatus;
   private Long partnerId;
   private Long categoryId;
+  private boolean isOpened;
 
   private StorePhoto storePhoto;
   private StoreProfilePhoto storeProfilePhoto;
@@ -64,6 +65,7 @@ public class StoreDto {
     accessStatus = store.isAccessStatus();
     categoryId = store.getCategory().getCategoryId();
     partnerId = store.getPartner().getPartnerId();
+    isOpened = store.isOpened();
   }
 
   public Store toEntity() {
@@ -78,6 +80,7 @@ public class StoreDto {
         .businessNumber(businessNumber)
         .openTime(openTime)
         .endTime(endTime)
+        .isOpened(isOpened)
         .totalStars(totalStars)
         .totalReviews(totalReviews)
         .leastOrderCost(leastOrderCost)

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/AdditionalMenu.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/AdditionalMenu.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.store.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,15 +28,17 @@ public class AdditionalMenu extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long additionalMenuId;
 
+  @Column(nullable = false)
   private String menuName;
-
+  @Column(nullable = false, columnDefinition = "INT CHECK (price >= 0)")
   private int price;
+  @Column(nullable = false, columnDefinition = "INT CHECK (sequence > 0)")
   private int sequence;
 
   private boolean soldOutStatus;
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "menu_id")
+  @JoinColumn(name = "menu_id", nullable = false)
   private Menu menu;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/Category.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/Category.java
@@ -26,6 +26,6 @@ public class Category extends BaseEntity {
   @Column(unique = true)
   private String name;
 
-  @Column(unique = true)
+  @Column(unique = true, columnDefinition = "INT CHECK (sequence > 0)")
   private int sequence;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/Menu.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/Menu.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.store.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,16 +30,19 @@ public class Menu extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long menuId;
 
+  @Column(nullable = false)
   private String menuName;
 
+  @Column(nullable = false, columnDefinition = "INT CHECK (price > 0)")
   private int price;
   private String description;
 
+  @Column(nullable = false)
   private boolean soldOutStatus;
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "category_id")
+  @JoinColumn(name = "category_id", nullable = false)
   private MenuCategory menuCategory;
 
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/Menu.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/Menu.java
@@ -40,4 +40,5 @@ public class Menu extends BaseEntity {
   @ManyToOne
   @JoinColumn(name = "category_id")
   private MenuCategory menuCategory;
+
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/MenuCategory.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/MenuCategory.java
@@ -29,9 +29,10 @@ public class MenuCategory extends BaseEntity {
   @Column(unique = true)
   private String name;
 
+  @Column(nullable = false)
   private int sequence;
 
   @ManyToOne
-  @JoinColumn(name = "store_id")
+  @JoinColumn(name = "store_id", nullable = false)
   private Store store;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/MenuPhoto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/MenuPhoto.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.store.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,12 +28,14 @@ public class MenuPhoto extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long menuPhotoId;
 
+  @Column(nullable = false)
   private String url;
+  @Column(nullable = false)
   private String photoName;
 
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "menu_id")
+  @JoinColumn(name = "menu_id", nullable = false)
   private Menu menu;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/Store.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/Store.java
@@ -53,15 +53,15 @@ public class Store extends BaseEntity {
   @Column(nullable = false)
   private LocalTime endTime;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "INT CHECK (total_stars > 0)")
   private Long totalStars;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "INT CHECK (total_reviews > 0)")
   private Long totalReviews;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "INT CHECK (least_order_cost >= 0)")
   private int leastOrderCost;
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "INT CHECK (delivery_cost >= 0)")
   private int deliveryCost;
   private String originNotation;
 
@@ -74,11 +74,11 @@ public class Store extends BaseEntity {
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "partner_id")
+  @JoinColumn(name = "partner_id", nullable = false)
   private Partner partner;
 
   @ManyToOne
-  @JoinColumn(name = "category_id")
+  @JoinColumn(name = "category_id", nullable = false)
   private Category category;
 
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/Store.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/Store.java
@@ -68,6 +68,9 @@ public class Store extends BaseEntity {
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean accessStatus;
 
+  @Column(nullable = false, columnDefinition = "boolean default false")
+  private boolean isOpened;
+
   private LocalDateTime deletedAt;
 
   @ManyToOne

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/StorePhoto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/StorePhoto.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.store.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,12 +29,14 @@ public class StorePhoto extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long storePhotoId;
 
+  @Column(nullable = false)
   private String url;
+  @Column(nullable = false)
   private String photoName;
 
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "store_id")
+  @JoinColumn(name = "store_id", nullable = false)
   private Store store;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/entity/StoreProfilePhoto.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/entity/StoreProfilePhoto.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.store.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,12 +28,14 @@ public class StoreProfilePhoto extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long storeProfilePhotoId;
 
+  @Column(nullable = false)
   private String url;
+  @Column(nullable = false)
   private String photoName;
 
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "store_id")
+  @JoinColumn(name = "store_id", nullable = false)
   private Store store;
 }

--- a/src/main/java/com/younggeun/delivery/store/domain/type/OrderStatus.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/type/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.younggeun.delivery.store.domain.type;
+
+public enum OrderStatus {
+  WAIT, WITHDRAW, REFUSE, PAYMENT, ACCEPT, DELIVERY_COMPLETED
+}

--- a/src/main/java/com/younggeun/delivery/store/domain/type/OrderType.java
+++ b/src/main/java/com/younggeun/delivery/store/domain/type/OrderType.java
@@ -1,5 +1,5 @@
 package com.younggeun.delivery.store.domain.type;
 
 public enum OrderType {
-  cost, star, dist
+  COST, STAR, DIST
 }

--- a/src/main/java/com/younggeun/delivery/store/service/MenuService.java
+++ b/src/main/java/com/younggeun/delivery/store/service/MenuService.java
@@ -63,15 +63,14 @@ public class MenuService {
     Map<Long, MenuListDto> menuListDtoMap = menuListDtos.stream().collect(Collectors.toMap(MenuListDto::getCategoryId, Function.identity()));
 
     // 카테고리별로 메뉴를 가져오고 DTO로 변환
-    List<Menu> menuList = menuRepository.findAllByMenuCategoryId(menuCategoryList.stream().map(MenuCategory::getCategoryId).collect(Collectors.toList()));
+    List<Menu> menuList = menuRepository.findAllByMenuCategoryCategoryIdIn(menuCategoryList.stream().map(MenuCategory::getCategoryId).collect(Collectors.toList()));
     Map<Long, List<Menu>> menuMap = menuList.stream().collect(Collectors.groupingBy(menu -> menu.getMenuCategory().getCategoryId()));
 
     List<Long> menuIdList = menuList.stream().map(Menu::getMenuId).collect(Collectors.toList());
 
     // 메뉴 사진을 가져오고 메뉴 ID를 키로하여 매핑
-    Map<Long, PhotoDto> menuPhotoMap = menuPhotoRepository.findAllByMenuId(menuIdList).stream()
+    Map<Long, PhotoDto> menuPhotoMap = menuPhotoRepository.findAllByMenuMenuIdIn(menuIdList).stream()
         .collect(Collectors.toMap(photo -> photo.getMenu().getMenuId(), PhotoDto::new));
-
 
     // 메뉴 DTO에 메뉴 사진 및 추가 메뉴 매핑
     for (MenuCategory menuCategory : menuCategoryList) {

--- a/src/main/java/com/younggeun/delivery/store/service/StoreService.java
+++ b/src/main/java/com/younggeun/delivery/store/service/StoreService.java
@@ -180,11 +180,11 @@ public class StoreService {
     User user = getUser(authentication);
     DeliveryAddress deliveryAddress = getDeliveryAddress(user, deliveryAddressDto.getAddressId());
 
-    if(type == OrderType.star) {
+    if(type == OrderType.STAR) {
       return storeToDto(storeRepository.findAllByAddress2OrderByStar(deliveryAddress.getAddress2()));
-    } else if(type == OrderType.dist) {
+    } else if(type == OrderType.DIST) {
       return storeToDto(storeRepository.findAllByAddress2OrderByDist(deliveryAddress.getAddress2(), deliveryAddress.getLatitude(), deliveryAddress.getLongitude()));
-    } else if(type == OrderType.cost) {
+    } else if(type == OrderType.COST) {
       return storeToDto(storeRepository.findAllByAddress2OrderByDeliveryCost(deliveryAddress.getAddress2()));
     } else {
       return storeToDto(storeRepository.findAllByAddress2OrderByDeliveryCost(deliveryAddress.getAddress2()));
@@ -246,11 +246,11 @@ public class StoreService {
     DeliveryAddress deliveryAddress = getDeliveryAddress(user, deliveryAddressDto.getAddressId());
     Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new RestApiException(STORE_CATEGORY_NOT_FOUND));
 
-    if(oT == OrderType.star) {
+    if(oT == OrderType.STAR) {
       return storeToDto(storeRepository.findAllByCategoryOrderByStar(deliveryAddress.getAddress2(), category.getCategoryId()));
-    } else if(oT == OrderType.dist) {
+    } else if(oT == OrderType.DIST) {
       return storeToDto(storeRepository.findAllByCategoryOrderByDist(deliveryAddress.getAddress2(), category.getCategoryId(), deliveryAddress.getLatitude(), deliveryAddress.getLongitude()));
-    } else if(oT == OrderType.cost) {
+    } else if(oT == OrderType.COST) {
       return storeToDto(storeRepository.findAllByAddress2AndCategoryOrderByDeliveryCost(deliveryAddress.getAddress2(), category));
     } else {
       return storeToDto(storeRepository.findAllByAddress2AndCategory(deliveryAddress.getAddress2(), category));

--- a/src/main/java/com/younggeun/delivery/user/controller/CartController.java
+++ b/src/main/java/com/younggeun/delivery/user/controller/CartController.java
@@ -1,0 +1,59 @@
+package com.younggeun.delivery.user.controller;
+
+import com.younggeun.delivery.user.domain.dto.CartDto;
+import com.younggeun.delivery.user.service.ShoppingCartService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/users/cart")
+@RequiredArgsConstructor
+public class CartController {
+  private final ShoppingCartService shoppingCartService;
+
+  @Operation(summary = "user cart 조회", description = "authentication")
+  @GetMapping
+  public ResponseEntity<?> getCartList(Authentication authentication) {
+    var result = this.shoppingCartService.getCart(authentication.getName());
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "user cart 추가", description = "authentication")
+  @PostMapping
+  public ResponseEntity<?> addMenuToCart(Authentication authentication, @RequestBody CartDto menuDto) {
+    var result = this.shoppingCartService.addToCart(authentication.getName(), menuDto);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "user cart 수정", description = "authentication")
+  @PutMapping("/{cartId}")
+  public ResponseEntity<?> updateMenuToCart(Authentication authentication,@PathVariable String cartId, @RequestBody CartDto menuDto) {
+    var result = this.shoppingCartService.updateCartMenu(authentication.getName(), cartId, menuDto);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "user cart 삭제", description = "authentication")
+  @DeleteMapping("/{cartId}")
+  public ResponseEntity<?> removeMenuToCart(Authentication authentication, @PathVariable String cartId) {
+    var result = this.shoppingCartService.removeFromCart(authentication.getName(), cartId);
+
+    return ResponseEntity.ok(result);
+  }
+
+
+}

--- a/src/main/java/com/younggeun/delivery/user/controller/KakaoPayController.java
+++ b/src/main/java/com/younggeun/delivery/user/controller/KakaoPayController.java
@@ -1,0 +1,79 @@
+package com.younggeun.delivery.user.controller;
+
+import static com.younggeun.delivery.global.exception.type.PayErrorCode.KAKAOPAY_FAILED;
+import static com.younggeun.delivery.global.exception.type.PayErrorCode.KAKOPAY_CANCELED;
+
+import com.younggeun.delivery.global.exception.RestApiException;
+import com.younggeun.delivery.user.domain.dto.KakaoCancelResponse;
+import com.younggeun.delivery.user.domain.dto.KakaoReadyResponse;
+import com.younggeun.delivery.user.domain.dto.KakaoRequestDto;
+import com.younggeun.delivery.user.service.KakaoPayService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("users/payment/kakao")
+@RequiredArgsConstructor
+public class KakaoPayController {
+
+  private final KakaoPayService kakaoPayService;
+
+  private KakaoRequestDto kakaoRequestDto;
+
+  /**
+   * 결제요청
+   */
+  @PostMapping("/ready")
+  public String readyToKakaoPay(Authentication authentication) {
+    KakaoReadyResponse kakaoReadyResponse = kakaoPayService.kakaoPayReady(authentication);
+    kakaoRequestDto = kakaoReadyResponse.getRequestDto();
+    return "redirect:" + kakaoReadyResponse.getNext_redirect_pc_url();
+  }
+
+  /**
+   * 결제 성공
+   */
+  @GetMapping("/success")
+  public String afterPayRequest(HttpServletRequest request, Authentication authentication, @RequestParam("pg_token") String pgToken) {
+    kakaoRequestDto.setPgToken(pgToken);
+
+    return kakaoPayService.approveResponse(kakaoRequestDto, authentication, request.getHeader("Authorization"));
+  }
+
+  /**
+   * 결제 진행 중 취소
+   */
+  @GetMapping("/cancel")
+  public void cancel() {
+
+    throw new RestApiException(KAKOPAY_CANCELED);
+  }
+
+  /**
+   * 결제 실패
+   */
+  @GetMapping("/fail")
+  public void fail() {
+
+    throw new RestApiException(KAKAOPAY_FAILED);
+  }
+
+  /**
+   * 환불
+   */
+  @PostMapping("/refund")
+  public ResponseEntity refund(Authentication authentication) {
+
+    KakaoCancelResponse kakaoCancelResponse = kakaoPayService.kakaoCancel(authentication);
+
+    return new ResponseEntity<>(kakaoCancelResponse, HttpStatus.OK);
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/controller/OrderController.java
+++ b/src/main/java/com/younggeun/delivery/user/controller/OrderController.java
@@ -44,7 +44,6 @@ public class OrderController {
   public ResponseEntity<?> createOrder(Authentication authentication, @RequestBody KakaoApproveResponse kakaoApproveResponse) {
     var result = this.orderService.createOrder(authentication, kakaoApproveResponse);
 
-    // 주문 불가시 장바구니로 이동
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/com/younggeun/delivery/user/controller/OrderController.java
+++ b/src/main/java/com/younggeun/delivery/user/controller/OrderController.java
@@ -1,0 +1,58 @@
+package com.younggeun.delivery.user.controller;
+
+import com.younggeun.delivery.user.domain.dto.KakaoApproveResponse;
+import com.younggeun.delivery.user.domain.dto.OrderDto;
+import com.younggeun.delivery.user.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/users/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+  private final OrderService orderService;
+
+  @Operation(summary = "주문 목록 조회", description = "authentication")
+  @GetMapping
+  public ResponseEntity<?> getOrderList(Authentication authentication, Pageable pageable) {
+    var result = this.orderService.getOrderList(authentication, pageable);
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "주문하기", description = "authentication")
+  @PostMapping
+  public String createOrder(Authentication authentication, @RequestBody OrderDto orderDto) {
+    var result = this.orderService.saveOrder(authentication, orderDto);
+    return "redirect:http://localhost:8080/users/payment/kakao/ready";
+  }
+
+  @Operation(summary = "주문하기", description = "authentication")
+  @PostMapping("/success")
+  public ResponseEntity<?> createOrder(Authentication authentication, @RequestBody KakaoApproveResponse kakaoApproveResponse) {
+    var result = this.orderService.createOrder(authentication, kakaoApproveResponse);
+
+    // 주문 불가시 장바구니로 이동
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(summary = "주문 상세 조회", description = "authentication")
+  @GetMapping("/{orderId}")
+  public ResponseEntity<?> getOrder(Authentication authentication, @PathVariable String orderId) {
+    var result = orderService.getUserOrder(authentication, orderId);
+
+    return ResponseEntity.ok(result);
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/controller/UserController.java
+++ b/src/main/java/com/younggeun/delivery/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.younggeun.delivery.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -42,7 +43,8 @@ public class UserController {
   public ResponseEntity<?> signin(@RequestBody Auth.SignIn request) {
     var user = this.userService.authenticate(request);
     var token = this.tokenProvider.generateToken(user.getEmail(), user.getRole());
-
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authenticate", "Bearer " + token);
     return ResponseEntity.ok(token);
   }
 

--- a/src/main/java/com/younggeun/delivery/user/domain/OrderHistoryRepository.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/OrderHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.younggeun.delivery.user.domain;
+
+import com.younggeun.delivery.user.domain.entity.OrderHistory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long> {
+
+  List<OrderHistory> findAllByOrderTableOrderId(Long orderId);
+
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/OrderRepository.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/OrderRepository.java
@@ -1,0 +1,17 @@
+package com.younggeun.delivery.user.domain;
+
+import com.younggeun.delivery.store.domain.entity.Store;
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.entity.OrderTable;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<OrderTable, Long> {
+
+  Page<OrderTable> findAllByUserUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+  Page<OrderTable> findAllByStoreAndStatusGreaterThanAndUpdatedAtBetweenOrderByUpdatedAtDesc(Store store,
+      OrderStatus status, LocalDateTime openTime, LocalDateTime closeTime, Pageable pageable);
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/PaymentHistoryRepository.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/PaymentHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.younggeun.delivery.user.domain;
+
+import com.younggeun.delivery.user.domain.entity.PaymentHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/CartDto.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/CartDto.java
@@ -1,0 +1,23 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import com.younggeun.delivery.store.domain.dto.AdditionalMenuDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CartDto {
+  private Long cartId;
+  private Long storeId;
+  private int totalCost;
+  private CartMenuDto menu;
+  private int quantity;
+  private List<AdditionalMenuDto> additionalMenuList;
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/CartMenuDto.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/CartMenuDto.java
@@ -1,0 +1,32 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import com.younggeun.delivery.store.domain.entity.Menu;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CartMenuDto {
+  private Long menuId;
+  private String menuName;
+
+  private int price;
+  private Long categoryId;
+  private Long storeId;
+  private String description;
+
+  public CartMenuDto(Menu menu) {
+    this.menuId = menu.getMenuId();
+    this.menuName = menu.getMenuName();
+    this.price = menu.getPrice();
+    this.categoryId = menu.getMenuCategory().getCategoryId();
+    this.description = menu.getDescription();
+    this.storeId = menu.getMenuCategory().getStore().getStoreId();
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoApproveResponse.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoApproveResponse.java
@@ -1,0 +1,28 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import com.younggeun.delivery.user.domain.entity.Amount;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 결제 승인 요청 시 사용
+ */
+@Getter
+@Setter
+@ToString
+public class KakaoApproveResponse {
+  private String tid; // 결제 고유 번호
+  private String cid; // 가맹점 코드
+  private String sid; // 정기결제용 ID
+  private String partner_order_id; // 가맹점 주문 번호
+  private String partner_user_id; // 가맹점 회원 id
+  private String payment_method_type; // 결제 수단
+  private Amount amount; // 결제 금액 정보
+  private String item_name; // 상품명
+  private String item_code; // 상품 코드
+  private int quantity; // 상품 수량
+  private String created_at; // 결제 요청 시간
+  private String approved_at; // 결제 승인 시간
+  private String payload; // 결제 승인 요청에 대해 저장 값, 요청 시 전달 내용
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoCancelResponse.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoCancelResponse.java
@@ -1,0 +1,81 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import com.younggeun.delivery.user.domain.entity.Amount;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 결제 취소 요청 시 사용
+ */
+@Getter
+@Setter
+@ToString
+public class KakaoCancelResponse {
+  private String aid; // 요청 고유 번호
+  private String tid; // 결제 고유 번호
+  private String cid; // 가맹점 코드
+  private String status; // 결제 상태
+  private String partner_order_id; // 가맹점 주문 번호
+  private String partner_user_id; // 가맹점 회원 ID
+  private String payment_method_type; // 결제 수단
+  private Amount amount; // 결제 금액 정보, 결제 요청 구현할때 이미 구현해놓음
+  private ApprovedCancelAmount approved_cancel_amount; // 이번 요청으로 취소된 금액
+  private CanceledAmount canceled_amount; // 누계 취소 금액
+  private CancelAvailableAmount cancel_available_amount; // 남은 취소 금액
+  private String item_name; // 상품 이름
+  private String item_code; // 상품 코드
+  private int quantity; // 상품 수량
+  private String created_at; // 결제 준비 요청 시각
+  private String approved_at; // 결제 승인 시각
+  private String canceled_at; // 결제 취소 시각
+  private String payload; // 취소 요청 시 전달한 값
+
+  /**
+   * 이번 요청으로 취소된 금액
+   */
+  @Getter
+  @Setter
+  @ToString
+  public static class ApprovedCancelAmount {
+
+    private int total; // 이번 요청으로 취소된 전체 금액
+    private int tax_free; // 이번 요청으로 취소된 비과세 금액
+    private int vat; // 이번 요청으로 취소된 부가세 금액
+    private int point; // 이번 요청으로 취소된 포인트 금액
+    private int discount; // 이번 요청으로 취소된 할인 금액
+    private int green_deposit; // 컵 보증금
+  }
+
+  /**
+   * 누계 취소 금액
+   */
+  @Getter
+  @Setter
+  @ToString
+  public static class CanceledAmount {
+
+    private int total; // 취소된 전체 누적 금액
+    private int tax_free; // 취소된 비과세 누적 금액
+    private int vat; // 취소된 부가세 누적 금액
+    private int point; // 취소된 포인트 누적 금액
+    private int discount; // 취소된 할인 누적 금액
+    private int green_deposit; // 컵 보증금
+  }
+
+  /**
+   * 취소 요청 시 전달한 값
+   */
+  @Getter
+  @Setter
+  @ToString
+  public static class CancelAvailableAmount {
+
+    private int total; // 전체 취소 가능 금액
+    private int tax_free; // 취소 가능 비과세 금액
+    private int vat; // 취소 가능 부가세 금액
+    private int point; // 취소 가능 포인트 금액
+    private int discount; // 취소 가능 할인 금액
+    private int green_deposit; // 컵 보증금
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoReadyResponse.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoReadyResponse.java
@@ -1,0 +1,17 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoReadyResponse {
+  private String tid; // 결제 고유 번호
+  private String next_redirect_mobile_url; // 모바일 웹일 경우 받는 결제페이지 url
+  private String next_redirect_pc_url; // pc 웹일 경우 받는 결제 페이지
+  private String created_at;
+  private KakaoRequestDto requestDto;
+
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoRequestDto.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/KakaoRequestDto.java
@@ -1,0 +1,23 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoRequestDto {
+  private String tid; // 결제 고유 번호
+  private String next_redirect_mobile_url; // 모바일 웹일 경우 받는 결제페이지 url
+  private String next_redirect_pc_url; // pc 웹일 경우 받는 결제 페이지
+  private String created_at;
+  private String partnerOrderId;
+  private String partnerUserId;
+  private String itemName;
+  private int quantity;
+  private int totalPrice;
+  private int vatAmount;
+  private int texFreeAmount;
+  private String pgToken;
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/dto/OrderDto.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/dto/OrderDto.java
@@ -1,0 +1,68 @@
+package com.younggeun.delivery.user.domain.dto;
+
+import com.younggeun.delivery.store.domain.entity.Store;
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.entity.DeliveryAddress;
+import com.younggeun.delivery.user.domain.entity.OrderTable;
+import com.younggeun.delivery.user.domain.entity.User;
+import com.younggeun.delivery.user.domain.type.PaymentType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderDto {
+  private Long orderId;
+  private int totalPrice;
+  private OrderStatus status;
+  private String request;
+  private LocalDateTime deliveryTime;
+  private PaymentType paymentType;
+  private Long addressId;
+  private Long userId;
+  private Long storeId;
+
+  public OrderDto(OrderTable orderTable) {
+    this.orderId = orderTable.getOrderId();
+    this.totalPrice = orderTable.getTotalPrice();
+    this.status = orderTable.getStatus();
+    this.request = orderTable.getRequest();
+    this.deliveryTime = orderTable.getDeliveryTime();
+    this.paymentType = orderTable.getPaymentType();
+    this.addressId = orderTable.getAddress().getAddressId();
+    this.storeId = orderTable.getStore().getStoreId();
+    this.userId = orderTable.getUser().getUserId();
+  }
+
+  public OrderDto(KakaoApproveResponse kakaoApproveResponse) {
+    this.totalPrice = kakaoApproveResponse.getAmount().getTotal();
+    this.status = OrderStatus.PAYMENT;
+    this.paymentType = PaymentType.KAKAOPAY;
+  }
+
+  public void setOrderDto(KakaoApproveResponse kakaoApproveResponse) {
+    this.totalPrice = kakaoApproveResponse.getAmount().getTotal();
+    this.status = OrderStatus.PAYMENT;
+    this.paymentType = PaymentType.KAKAOPAY;
+  }
+
+  public OrderTable toEntity(String request, Store store, User user, DeliveryAddress address) {
+    return OrderTable.builder()
+        .deliveryTime(null)
+        .request(request)
+        .address(address)
+        .user(user)
+        .store(store)
+        .status(status)
+        .paymentType(paymentType)
+        .totalPrice(totalPrice)
+        .build();
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/Amount.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/Amount.java
@@ -1,0 +1,21 @@
+package com.younggeun.delivery.user.domain.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 결제 금액 정보
+ */
+@Getter
+@Setter
+@ToString
+public class Amount {
+
+  private int total; // 총 결제 금액
+  private int tax_free; // 비과세 금액
+  private int tax; // 부가세 금액
+  private int point; // 사용한 포인트
+  private int discount; // 할인금액
+  private int green_deposit; // 컵 보증금
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/Cart.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/Cart.java
@@ -1,0 +1,19 @@
+package com.younggeun.delivery.user.domain.entity;
+
+import com.younggeun.delivery.user.domain.dto.CartDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Cart {
+
+    private List<CartDto> items;
+
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/DeliveryAddress.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/DeliveryAddress.java
@@ -1,6 +1,7 @@
 package com.younggeun.delivery.user.domain.entity;
 
 import com.younggeun.delivery.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -26,21 +27,25 @@ public class DeliveryAddress extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long addressId;
-
+  @Column(nullable = false)
   private String name;
-
+  @Column(nullable = false)
   private String address1;
+  @Column(nullable = false)
   private String address2;
+  @Column(nullable = false)
   private String address3;
-
+  @Column(nullable = false)
   private double latitude;
+  @Column(nullable = false)
   private double longitude;
-
+  @Column(nullable = false)
   private boolean defaultAddressStatus;
+
   private LocalDateTime deletedAt;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
 }

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/OrderHistory.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/OrderHistory.java
@@ -1,0 +1,58 @@
+package com.younggeun.delivery.user.domain.entity;
+
+import com.younggeun.delivery.store.domain.entity.AdditionalMenu;
+import com.younggeun.delivery.store.domain.entity.Menu;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedEntityGraph;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@NamedEntityGraph
+@Builder
+@Getter
+@Entity
+public class OrderHistory {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long OrderHistoryId;
+
+  private int quantity;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @ManyToOne
+  @JoinColumn(name = "order_id")
+  private OrderTable orderTable;
+
+  @ManyToOne
+  @JoinColumn(name = "menu_id")
+  private Menu menu;
+
+  @ManyToOne
+  @JoinColumn(name = "additional_menu_id")
+  private AdditionalMenu additionalMenu;
+
+  public OrderHistory(OrderTable orderTable, Menu menu, int quantity) {
+    this.orderTable = orderTable;
+    this.menu = menu;
+    this.quantity = quantity;
+  }
+
+  public OrderHistory(OrderTable orderTable, AdditionalMenu additionalMenu, int quantity) {
+    this.orderTable = orderTable;
+    this.additionalMenu = additionalMenu;
+    this.quantity = quantity;
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/OrderHistory.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/OrderHistory.java
@@ -2,6 +2,7 @@ package com.younggeun.delivery.user.domain.entity;
 
 import com.younggeun.delivery.store.domain.entity.AdditionalMenu;
 import com.younggeun.delivery.store.domain.entity.Menu;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,13 +28,14 @@ public class OrderHistory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long OrderHistoryId;
 
+  @Column(nullable = false, columnDefinition = "INT CHECK (quantity > 0)")
   private int quantity;
 
   @CreatedDate
   private LocalDateTime createdAt;
 
   @ManyToOne
-  @JoinColumn(name = "order_id")
+  @JoinColumn(name = "order_id", nullable = false)
   private OrderTable orderTable;
 
   @ManyToOne

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/OrderTable.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/OrderTable.java
@@ -1,0 +1,51 @@
+package com.younggeun.delivery.user.domain.entity;
+
+import com.younggeun.delivery.global.entity.BaseEntity;
+import com.younggeun.delivery.store.domain.entity.Store;
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.type.PaymentType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedEntityGraph;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@NamedEntityGraph
+@Builder
+@Getter
+@Setter
+@Entity
+public class OrderTable extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long orderId;
+
+  private int totalPrice;
+  private OrderStatus status;
+  private String request;
+  private LocalDateTime deliveryTime;
+  private PaymentType paymentType;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "address_id")
+  private DeliveryAddress address;
+
+  @ManyToOne
+  @JoinColumn(name = "store_id")
+  private Store store;
+
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/OrderTable.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/OrderTable.java
@@ -4,7 +4,9 @@ import com.younggeun.delivery.global.entity.BaseEntity;
 import com.younggeun.delivery.store.domain.entity.Store;
 import com.younggeun.delivery.store.domain.type.OrderStatus;
 import com.younggeun.delivery.user.domain.type.PaymentType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,22 +32,29 @@ public class OrderTable extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long orderId;
 
+  @Column(nullable = false, columnDefinition = "INT CHECK (total_price > 0)")
   private int totalPrice;
+
+  @Enumerated
+  @Column(nullable = false)
   private OrderStatus status;
   private String request;
   private LocalDateTime deliveryTime;
+
+  @Enumerated
+  @Column(nullable = false)
   private PaymentType paymentType;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @ManyToOne
-  @JoinColumn(name = "address_id")
+  @JoinColumn(name = "address_id", nullable = false)
   private DeliveryAddress address;
 
   @ManyToOne
-  @JoinColumn(name = "store_id")
+  @JoinColumn(name = "store_id", nullable = false)
   private Store store;
 
 }

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/PaymentHistory.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/PaymentHistory.java
@@ -3,7 +3,9 @@ package com.younggeun.delivery.user.domain.entity;
 import com.younggeun.delivery.user.domain.dto.KakaoApproveResponse;
 import com.younggeun.delivery.user.domain.type.PaymentStatusType;
 import com.younggeun.delivery.user.domain.type.PaymentType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,18 +29,29 @@ public class PaymentHistory {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long paymentHistoryId;
 
+  @Column(nullable = false)
   private String tid; // 결제 고유 번호
+  @Column(nullable = false)
   private String cid; // 가맹점 코드
+  @Column(nullable = false)
   private String partnerUserId;
+  @Column(nullable = false, columnDefinition = "INT CHECK (quantity > 0)")
   private int quantity; // 상품 수량
+  @Column(nullable = false)
   private LocalDateTime createdAt; // 결제 요청 시간
+  @Column(nullable = false)
   private LocalDateTime approvedAt; // 결제 승인 시간
+  @Enumerated
+  @Column(nullable = false)
   private PaymentType paymentType;
+  @Column(nullable = false, columnDefinition = "INT CHECK (total_price > 0)")
   private int totalPrice;
+  @Enumerated
+  @Column(nullable = false)
   private PaymentStatusType status;
 
   @OneToOne
-  @JoinColumn(name = "order_id")
+  @JoinColumn(name = "order_id", nullable = false)
   private OrderTable orderTable;
 
   public PaymentHistory(KakaoApproveResponse response, OrderTable orderTable) {

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/PaymentHistory.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/PaymentHistory.java
@@ -1,0 +1,56 @@
+package com.younggeun.delivery.user.domain.entity;
+
+import com.younggeun.delivery.user.domain.dto.KakaoApproveResponse;
+import com.younggeun.delivery.user.domain.type.PaymentStatusType;
+import com.younggeun.delivery.user.domain.type.PaymentType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@NamedEntityGraph
+@Builder
+@Getter
+@Entity
+public class PaymentHistory {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long paymentHistoryId;
+
+  private String tid; // 결제 고유 번호
+  private String cid; // 가맹점 코드
+  private String partnerUserId;
+  private int quantity; // 상품 수량
+  private LocalDateTime createdAt; // 결제 요청 시간
+  private LocalDateTime approvedAt; // 결제 승인 시간
+  private PaymentType paymentType;
+  private int totalPrice;
+  private PaymentStatusType status;
+
+  @OneToOne
+  @JoinColumn(name = "order_id")
+  private OrderTable orderTable;
+
+  public PaymentHistory(KakaoApproveResponse response, OrderTable orderTable) {
+    this.orderTable = orderTable;
+    this.tid = response.getTid();
+    this.cid = response.getCid();
+    this.partnerUserId = response.getPartner_user_id();
+    this.totalPrice = response.getAmount().getTotal();
+    this.quantity = response.getQuantity();
+    this.createdAt = LocalDateTime.parse(response.getCreated_at());
+    this.approvedAt = LocalDateTime.parse(response.getApproved_at());
+    this.paymentType = PaymentType.KAKAOPAY;
+    this.status = PaymentStatusType.PAYED;
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/User.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/User.java
@@ -37,12 +37,14 @@ public class User extends BaseEntity {
   @Column(nullable = false)
   private String password;
 
+  @Column(nullable = false)
   private String username;
 
   @Column(unique = true)
   private String nickname;
 
   @Column(nullable = false)
+  @Enumerated
   private AuthType authType;
 
   private String provider; //어떤 OAuth인지(google, naver 등)

--- a/src/main/java/com/younggeun/delivery/user/domain/entity/Wish.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/entity/Wish.java
@@ -25,11 +25,11 @@ public class Wish {
   private Long wishId;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @ManyToOne
-  @JoinColumn(name = "store_id")
+  @JoinColumn(name = "store_id", nullable = false)
   private Store store;
 
   @CreatedDate

--- a/src/main/java/com/younggeun/delivery/user/domain/type/PaymentStatusType.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/type/PaymentStatusType.java
@@ -1,0 +1,5 @@
+package com.younggeun.delivery.user.domain.type;
+
+public enum PaymentStatusType {
+  PAYED, CANCEL
+}

--- a/src/main/java/com/younggeun/delivery/user/domain/type/PaymentType.java
+++ b/src/main/java/com/younggeun/delivery/user/domain/type/PaymentType.java
@@ -1,0 +1,5 @@
+package com.younggeun.delivery.user.domain.type;
+
+public enum PaymentType {
+  KAKAOPAY
+}

--- a/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
@@ -1,0 +1,167 @@
+package com.younggeun.delivery.user.service;
+
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_IS_EMPTY;
+
+import com.younggeun.delivery.global.config.KakaoPayConfig;
+import com.younggeun.delivery.global.exception.RestApiException;
+import com.younggeun.delivery.user.domain.dto.CartDto;
+import com.younggeun.delivery.user.domain.dto.KakaoApproveResponse;
+import com.younggeun.delivery.user.domain.dto.KakaoCancelResponse;
+import com.younggeun.delivery.user.domain.dto.KakaoReadyResponse;
+import com.younggeun.delivery.user.domain.dto.KakaoRequestDto;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class KakaoPayService {
+
+  private ShoppingCartService cartService;
+  static final String cid = "TC0ONETIME";
+  public KakaoReadyResponse kakaoPayReady(Authentication authentication) {
+    List<CartDto> cartDtoList = cartService.getCart(authentication.getName());
+    KakaoRequestDto kakaoRequestDto = new KakaoRequestDto();
+    // 카카오페이 요청 양식
+    Map<String, String> parameters = getReadyParameters(authentication.getName(), cartDtoList, kakaoRequestDto);
+    // 파라미터, 헤더
+    HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeadersToDevKey());
+
+    try {
+      RestTemplate restTemplate = new RestTemplate();
+      ResponseEntity<KakaoReadyResponse> responseEntity = restTemplate.exchange(
+          KakaoPayConfig.readyUrlDev, HttpMethod.POST, requestEntity, KakaoReadyResponse.class);
+
+      kakaoRequestDto.setTid(responseEntity.getBody().getTid());
+      responseEntity.getBody().setRequestDto(kakaoRequestDto);
+      return responseEntity.getBody();
+    } catch (HttpClientErrorException e) {
+      throw new HttpClientErrorException(e.getStatusCode(), e.getMessage());
+    }
+  }
+
+  private Map<String, String> getReadyParameters(String userEmail,
+      List<CartDto> cartDtoList, KakaoRequestDto kakaoRequestDto) {
+    int quantity = cartDtoList.stream().mapToInt(CartDto::getQuantity).sum();
+    int totalCost = cartDtoList.stream().mapToInt(CartDto::getTotalCost).sum();
+    kakaoRequestDto.setItemName(cartDtoList.stream().findFirst().orElseThrow(() -> new RestApiException(CART_IS_EMPTY)).getMenu().getMenuName() + (cartDtoList.size() > 1 ? "외 " + (quantity-1) : "개"));
+    kakaoRequestDto.setQuantity(quantity);
+    kakaoRequestDto.setTotalPrice(totalCost);
+    kakaoRequestDto.setVatAmount(totalCost/11);
+    kakaoRequestDto.setTexFreeAmount(0);
+    kakaoRequestDto.setPartnerUserId(userEmail);
+    kakaoRequestDto.setPartnerOrderId(userEmail + LocalDateTime.now().withNano(0));
+
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("cid", cid);
+    parameters.put("partner_order_id", kakaoRequestDto.getPartnerOrderId());
+    parameters.put("partner_user_id", kakaoRequestDto.getPartnerUserId());
+    parameters.put("item_name", kakaoRequestDto.getItemName());
+    parameters.put("quantity", Integer.toString(kakaoRequestDto.getQuantity()));
+    parameters.put("total_amount", Integer.toString(kakaoRequestDto.getTotalPrice()));
+    parameters.put("vat_amount", Integer.toString(kakaoRequestDto.getVatAmount()));
+    parameters.put("tax_free_amount", Integer.toString(kakaoRequestDto.getTexFreeAmount()));
+    parameters.put("approval_url", "http://localhost:8080/users/payment/kakao/success"); // 성공 시 redirect url
+    parameters.put("cancel_url", "http://localhost:8080/users/payment/kakao/cancel"); // 취소 시 redirect url
+    parameters.put("fail_url", "http://localhost:8080/users/payment/kakao/fail"); // 실패 시 redirect url
+
+    return parameters;
+  }
+
+  /**
+   * 결제 완료 승인
+   */
+  public String approveResponse(KakaoRequestDto request, Authentication authentication,
+      String header) {
+    // 카카오 요청
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("cid", cid);
+    parameters.put("tid", request.getTid());
+    parameters.put("partner_order_id", request.getPartnerOrderId());
+    parameters.put("partner_user_id", request.getPartnerUserId());
+    parameters.put("pg_token", request.getPgToken());
+
+    // 파라미터, 헤더
+    HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeadersToDevKey());
+
+    // 외부에 보낼 url
+    RestTemplate restTemplate = new RestTemplate();
+    ResponseEntity<KakaoApproveResponse> responseEntity = restTemplate.exchange(
+        KakaoPayConfig.approveUrlDev, HttpMethod.POST, requestEntity, KakaoApproveResponse.class);
+
+    // POST 요청 생성
+    restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", header);
+    System.out.println(header);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<KakaoApproveResponse> newRequestEntity = new HttpEntity<>(responseEntity.getBody(), headers);
+
+    // POST 요청 보내기
+    ResponseEntity<String> newResponseEntity = restTemplate.postForEntity("http://localhost:8080/users/order/success?orderId=" + request, newRequestEntity, String.class);
+
+    return newResponseEntity.getBody();
+  }
+
+  /**
+   * 결제 환불
+   */
+  public KakaoCancelResponse kakaoCancel(Authentication authentication) {
+
+    // 카카오페이 요청
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("cid", cid);
+    parameters.put("tid", "환불할 결제 고유 번호");
+    parameters.put("cancel_amount", "환불 금액");
+    parameters.put("cancel_tax_free_amount", "환불 비과세 금액");
+    parameters.put("cancel_vat_amount", "환불 부가세");
+
+    // 파라미터, 헤더
+    HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, this.getHeadersToDevKey());
+
+    // 외부에 보낼 url
+    RestTemplate restTemplate = new RestTemplate();
+
+    ResponseEntity<KakaoCancelResponse> responseEntity = restTemplate.exchange(
+        KakaoPayConfig.cancelUrlDev, HttpMethod.POST, requestEntity, KakaoCancelResponse.class);
+
+    return responseEntity.getBody();
+  }
+
+  /**
+   * 카카오 요구 헤더값
+   */
+  private HttpHeaders getHeaders() {
+    HttpHeaders httpHeaders = new HttpHeaders();
+    String auth = "KakaoAK " + KakaoPayConfig.adminKey;
+
+    httpHeaders.set("Authorization", auth);
+    httpHeaders.set("Content-type",  "application/x-www-form-urlencoded;charset=utf-8");
+
+    return httpHeaders;
+  }
+
+  private HttpHeaders getHeadersToDevKey() {
+    HttpHeaders httpHeaders = new HttpHeaders();
+    String auth = "SECRET_KEY " + KakaoPayConfig.devKey;
+
+    httpHeaders.set("Authorization", auth);
+    httpHeaders.set("Content-type", "application/json");
+
+    return httpHeaders;
+  }
+
+}

--- a/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
@@ -30,7 +30,8 @@ import org.springframework.web.client.RestTemplate;
 @AllArgsConstructor
 public class KakaoPayService {
 
-  private ShoppingCartService cartService;
+  private final ShoppingCartService cartService;
+  private final KakaoPayConfig kakaoPayConfig;
   static final String cid = "TC0ONETIME";
   public KakaoReadyResponse kakaoPayReady(Authentication authentication) {
     List<CartDto> cartDtoList = cartService.getCart(authentication.getName());
@@ -43,7 +44,7 @@ public class KakaoPayService {
     try {
       RestTemplate restTemplate = new RestTemplate();
       ResponseEntity<KakaoReadyResponse> responseEntity = restTemplate.exchange(
-          KakaoPayConfig.readyUrlDev, HttpMethod.POST, requestEntity, KakaoReadyResponse.class);
+          kakaoPayConfig.getReadyUrlDev(), HttpMethod.POST, requestEntity, KakaoReadyResponse.class);
 
       kakaoRequestDto.setTid(responseEntity.getBody().getTid());
       responseEntity.getBody().setRequestDto(kakaoRequestDto);
@@ -100,7 +101,7 @@ public class KakaoPayService {
     // 외부에 보낼 url
     RestTemplate restTemplate = new RestTemplate();
     ResponseEntity<KakaoApproveResponse> responseEntity = restTemplate.exchange(
-        KakaoPayConfig.approveUrlDev, HttpMethod.POST, requestEntity, KakaoApproveResponse.class);
+        kakaoPayConfig.getApproveUrlDev(), HttpMethod.POST, requestEntity, KakaoApproveResponse.class);
 
     // POST 요청 생성
     restTemplate = new RestTemplate();
@@ -135,7 +136,7 @@ public class KakaoPayService {
     RestTemplate restTemplate = new RestTemplate();
 
     ResponseEntity<KakaoCancelResponse> responseEntity = restTemplate.exchange(
-        KakaoPayConfig.cancelUrlDev, HttpMethod.POST, requestEntity, KakaoCancelResponse.class);
+        kakaoPayConfig.getCancelUrlDev(), HttpMethod.POST, requestEntity, KakaoCancelResponse.class);
 
     return responseEntity.getBody();
   }
@@ -145,7 +146,7 @@ public class KakaoPayService {
    */
   private HttpHeaders getHeaders() {
     HttpHeaders httpHeaders = new HttpHeaders();
-    String auth = "KakaoAK " + KakaoPayConfig.adminKey;
+    String auth = "KakaoAK " + kakaoPayConfig.getAdminKey();
 
     httpHeaders.set("Authorization", auth);
     httpHeaders.set("Content-type",  "application/x-www-form-urlencoded;charset=utf-8");
@@ -155,7 +156,7 @@ public class KakaoPayService {
 
   private HttpHeaders getHeadersToDevKey() {
     HttpHeaders httpHeaders = new HttpHeaders();
-    String auth = "SECRET_KEY " + KakaoPayConfig.devKey;
+    String auth = "SECRET_KEY " + kakaoPayConfig.getDevKey();
 
     httpHeaders.set("Authorization", auth);
     httpHeaders.set("Content-type", "application/json");

--- a/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/KakaoPayService.java
@@ -106,12 +106,11 @@ public class KakaoPayService {
     restTemplate = new RestTemplate();
     HttpHeaders headers = new HttpHeaders();
     headers.set("Authorization", header);
-    System.out.println(header);
     headers.setContentType(MediaType.APPLICATION_JSON);
     HttpEntity<KakaoApproveResponse> newRequestEntity = new HttpEntity<>(responseEntity.getBody(), headers);
 
     // POST 요청 보내기
-    ResponseEntity<String> newResponseEntity = restTemplate.postForEntity("http://localhost:8080/users/order/success?orderId=" + request, newRequestEntity, String.class);
+    ResponseEntity<String> newResponseEntity = restTemplate.postForEntity("http://localhost:8080/users/order/success", newRequestEntity, String.class);
 
     return newResponseEntity.getBody();
   }

--- a/src/main/java/com/younggeun/delivery/user/service/OrderService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/OrderService.java
@@ -1,0 +1,186 @@
+package com.younggeun.delivery.user.service;
+
+import static com.younggeun.delivery.global.exception.type.PayErrorCode.LEAST_ORDER_COST;
+import static com.younggeun.delivery.global.exception.type.PayErrorCode.ORDER_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.MENU_SOLD_OUT;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.STORE_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.STORE_NOT_OPENED;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.ADDRESS_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_IS_EMPTY;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.MISMATCH_USER_EXCEPTION;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.MISMATCH_USER_ORDER;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.USER_NOT_FOUND_EXCEPTION;
+
+import com.younggeun.delivery.global.exception.RestApiException;
+import com.younggeun.delivery.store.domain.AdditionalMenuRepository;
+import com.younggeun.delivery.store.domain.MenuRepository;
+import com.younggeun.delivery.store.domain.StoreRepository;
+import com.younggeun.delivery.store.domain.dto.AdditionalMenuDto;
+import com.younggeun.delivery.store.domain.dto.MenuDto;
+import com.younggeun.delivery.store.domain.dto.OrderDetailDto;
+import com.younggeun.delivery.store.domain.entity.AdditionalMenu;
+import com.younggeun.delivery.store.domain.entity.Menu;
+import com.younggeun.delivery.store.domain.entity.Store;
+import com.younggeun.delivery.store.domain.type.OrderStatus;
+import com.younggeun.delivery.user.domain.DeliveryAddressRepository;
+import com.younggeun.delivery.user.domain.OrderHistoryRepository;
+import com.younggeun.delivery.user.domain.OrderRepository;
+import com.younggeun.delivery.user.domain.PaymentHistoryRepository;
+import com.younggeun.delivery.user.domain.UserRepository;
+import com.younggeun.delivery.user.domain.dto.CartDto;
+import com.younggeun.delivery.user.domain.dto.CartMenuDto;
+import com.younggeun.delivery.user.domain.dto.KakaoApproveResponse;
+import com.younggeun.delivery.user.domain.dto.OrderDto;
+import com.younggeun.delivery.user.domain.entity.DeliveryAddress;
+import com.younggeun.delivery.user.domain.entity.OrderHistory;
+import com.younggeun.delivery.user.domain.entity.OrderTable;
+import com.younggeun.delivery.user.domain.entity.PaymentHistory;
+import com.younggeun.delivery.user.domain.entity.User;
+import com.younggeun.delivery.user.domain.type.PaymentType;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class OrderService {
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final UserRepository userRepository;
+  private final MenuRepository menuRepository;
+  private final AdditionalMenuRepository additionalMenuRepository;
+  private final OrderRepository orderRepository;
+  private final StoreRepository storeRepository;
+  private final DeliveryAddressRepository addressRepository;
+  private final OrderHistoryRepository orderHistoryRepository;
+  private final PaymentHistoryRepository paymentHistoryRepository;
+  private final ShoppingCartService shoppingCartService;
+
+  public Page<OrderDto> getOrderList(Authentication authentication, Pageable pageable) {
+    User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+      return orderRepository.findAllByUserUserIdOrderByCreatedAtDesc(user.getUserId(), pageable).map(
+          OrderDto::new);
+  }
+
+  @Transactional
+  public OrderDto saveOrder(Authentication authentication, OrderDto orderDto) {
+    List<CartDto> cartDtoList = shoppingCartService.getCart(authentication.getName());
+    Long storeId = cartDtoList.stream().map(CartDto::getStoreId).findFirst().orElseThrow(() -> new RestApiException(CART_IS_EMPTY));
+    Store store = storeRepository.findById(storeId).orElseThrow(() -> new RestApiException(STORE_NOT_FOUND));
+
+    if(!store.isOpened()) throw new RestApiException(STORE_NOT_OPENED);
+
+    List<Long> menuIdList = cartDtoList.stream().map(CartDto::getMenu).map(CartMenuDto::getMenuId).toList();
+    List<Long> additionalMenuIdList = cartDtoList.stream()
+        .flatMap(cartDto -> cartDto.getAdditionalMenuList().stream())
+        .map(AdditionalMenuDto::getAdditionalMenuId)
+        .toList();
+
+    List<Menu> orderMenuList = menuRepository.findAllByMenuIdIn(menuIdList);
+
+    List<AdditionalMenu> additionalMenuList = additionalMenuRepository.findAllByAdditionalMenuIdIn(additionalMenuIdList);
+
+    int totalCost = cartDtoList.stream().mapToInt(CartDto::getTotalCost).sum();
+
+    if(totalCost < store.getLeastOrderCost()) {
+      throw new RestApiException(LEAST_ORDER_COST);
+    }
+
+    orderDto.setTotalPrice(totalCost + store.getDeliveryCost());
+
+    if(orderMenuList.stream().anyMatch(Menu::isSoldOutStatus) || additionalMenuList.stream().anyMatch(AdditionalMenu::isSoldOutStatus)) {
+      throw new RestApiException(MENU_SOLD_OUT);
+    }
+
+    User user = userRepository.findByEmail(authentication.getName()).orElseThrow(() -> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+
+    DeliveryAddress address = addressRepository.findByUserAndDefaultAddressStatusIsTrue(user).orElseThrow(() -> new RestApiException(ADDRESS_NOT_FOUND));
+
+    OrderTable orderTable= orderRepository.save(OrderTable.builder()
+        .totalPrice(orderDto.getTotalPrice())
+        .request(orderDto.getRequest())
+        .paymentType(PaymentType.KAKAOPAY)
+        .status(OrderStatus.WAIT)
+        .user(user)
+        .store(store)
+        .address(address)
+        .build()
+    );
+
+    List<OrderHistory> orderHistoryList = new ArrayList<>();
+    cartDtoList.forEach(cartDto  -> {
+      Menu menu = Menu.builder().menuId(cartDto.getMenu().getMenuId()).build();
+      int quantity = cartDto.getQuantity();
+      orderHistoryList.add(OrderHistory.builder().menu(menu).orderTable(orderTable).quantity(quantity).createdAt(LocalDateTime.now()).build());
+      cartDto.getAdditionalMenuList().forEach(additionalMenuDto -> {
+        AdditionalMenu additionalMenu = AdditionalMenu.builder().additionalMenuId(additionalMenuDto.getAdditionalMenuId()).build();
+        orderHistoryList.add(OrderHistory.builder().menu(menu).additionalMenu(additionalMenu).orderTable(orderTable).quantity(quantity).createdAt(
+            LocalDateTime.now()).build());
+      });
+    });
+
+    orderHistoryRepository.saveAll(orderHistoryList);
+
+    redisTemplate.opsForValue().set("order:"+authentication.getName(), orderTable.getOrderId());
+
+    return new OrderDto(orderTable);
+  }
+
+  @Transactional
+  public OrderDto createOrder(Authentication authentication, KakaoApproveResponse kakaoApproveResponse) {
+    if(!authentication.getName().equals(kakaoApproveResponse.getPartner_user_id())) {
+      throw new RestApiException(MISMATCH_USER_EXCEPTION);
+    }
+    Long orderId =  Long.valueOf((Integer)redisTemplate.opsForValue().get("order:" + authentication.getName()));
+
+    OrderTable orderTable = orderRepository.findById(orderId).orElseThrow(() -> new RestApiException(ORDER_NOT_FOUND));
+    orderTable.setStatus(OrderStatus.PAYMENT);
+    PaymentHistory paymentHistory = new PaymentHistory(kakaoApproveResponse, orderTable);
+
+    paymentHistoryRepository.save(paymentHistory);
+    OrderTable updateOrderTable = orderRepository.save(orderTable);
+
+    // 저장이 완료된 orderId 값 삭제
+    redisTemplate.delete("order:"+authentication.getName());
+
+    // 장바구니 비우기
+    redisTemplate.delete(authentication.getName());
+    return new OrderDto(updateOrderTable);
+  }
+
+
+  public OrderDetailDto getUserOrder(Authentication authentication, String orderId) {
+    User user = userRepository.findByEmail(authentication.getName()).orElseThrow(()-> new RestApiException(USER_NOT_FOUND_EXCEPTION));
+    OrderTable orderTable = orderRepository.findById(Long.valueOf(orderId)).orElseThrow(() -> new RestApiException(ORDER_NOT_FOUND));
+
+    if(user.getUserId() != orderTable.getUser().getUserId()) {
+      throw new RestApiException(MISMATCH_USER_ORDER);
+    }
+
+    List<OrderHistory> orderHistoryList = orderHistoryRepository.findAllByOrderTableOrderId(Long.valueOf(orderId));
+
+    List<Long> menuIdList = orderHistoryList.stream().map(OrderHistory::getMenu).filter(Objects::nonNull)
+        .map(Menu::getMenuId).distinct().toList();
+    List<MenuDto> menuList =  menuRepository.findAllByMenuIdIn(menuIdList).stream().map(MenuDto::new).toList();
+    Map<Long, ArrayList<AdditionalMenuDto>> additionalMenuMap = additionalMenuRepository.findAllByMenuMenuIdIn(menuIdList)
+        .stream().collect(Collectors.groupingBy(
+            additionalMenu -> additionalMenu.getMenu().getMenuId(),
+            Collectors.mapping(AdditionalMenuDto::new, Collectors.toCollection(ArrayList::new))
+        ));
+
+    menuList.forEach(menuDto -> menuDto.setAdditionalMenuList(additionalMenuMap.get(menuDto.getMenuId())));
+
+    return new OrderDetailDto(orderTable, menuList);
+  }
+}

--- a/src/main/java/com/younggeun/delivery/user/service/ShoppingCartService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/ShoppingCartService.java
@@ -1,6 +1,9 @@
 package com.younggeun.delivery.user.service;
 
+import static com.younggeun.delivery.global.exception.type.CommonErrorCode.DESERIALIZING_CART_EXCEPTION;
+import static com.younggeun.delivery.global.exception.type.CommonErrorCode.SERIALIZING_CART_EXCEPTION;
 import static com.younggeun.delivery.global.exception.type.StoreErrorCode.MENU_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.ORDER_MORE_THAN_ONE;
 import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_IS_EMPTY;
 import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_NOT_FOUND;
 import static com.younggeun.delivery.global.exception.type.UserErrorCode.DIFFERENT_STORE_IN_CART;
@@ -44,7 +47,7 @@ public class ShoppingCartService {
   }
 
   public List<CartDto> addToCart(String userEmail, CartDto menu) {
-
+    if(menu.getQuantity() < 1) throw new RestApiException(ORDER_MORE_THAN_ONE);
     if (Boolean.FALSE.equals(redisTemplate.hasKey(userEmail))) {
       Cart cart = new Cart();
       cart.setItems(new ArrayList<>());
@@ -152,7 +155,7 @@ public class ShoppingCartService {
     try {
       return new ObjectMapper().writeValueAsString(cart);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Error serializing cart", e);
+      throw new RestApiException(SERIALIZING_CART_EXCEPTION);
     }
   }
 
@@ -160,7 +163,7 @@ public class ShoppingCartService {
     try {
       return new ObjectMapper().readValue(json, Cart.class);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Error deserializing cart", e);
+      throw new RestApiException(DESERIALIZING_CART_EXCEPTION);
     }
   }
 }

--- a/src/main/java/com/younggeun/delivery/user/service/ShoppingCartService.java
+++ b/src/main/java/com/younggeun/delivery/user/service/ShoppingCartService.java
@@ -1,0 +1,166 @@
+package com.younggeun.delivery.user.service;
+
+import static com.younggeun.delivery.global.exception.type.StoreErrorCode.MENU_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_IS_EMPTY;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.CART_NOT_FOUND;
+import static com.younggeun.delivery.global.exception.type.UserErrorCode.DIFFERENT_STORE_IN_CART;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.younggeun.delivery.global.exception.RestApiException;
+import com.younggeun.delivery.store.domain.AdditionalMenuRepository;
+import com.younggeun.delivery.store.domain.MenuRepository;
+import com.younggeun.delivery.store.domain.dto.AdditionalMenuDto;
+import com.younggeun.delivery.store.domain.entity.AdditionalMenu;
+import com.younggeun.delivery.user.domain.dto.CartDto;
+import com.younggeun.delivery.user.domain.dto.CartMenuDto;
+import com.younggeun.delivery.user.domain.entity.Cart;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@AllArgsConstructor
+@Service
+public class ShoppingCartService {
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final MenuRepository menuRepository;
+  private final AdditionalMenuRepository additionalMenuRepository;
+
+  public List<CartDto> getCart(String userEmail) {
+
+    if (Boolean.FALSE.equals(redisTemplate.hasKey(userEmail))) {
+      return new ArrayList<>();
+    }
+
+    String cartJson = (String) redisTemplate.opsForValue().get(userEmail);
+
+    Cart cart = deserialize(cartJson);
+
+    return cart.getItems();
+  }
+
+  public List<CartDto> addToCart(String userEmail, CartDto menu) {
+
+    if (Boolean.FALSE.equals(redisTemplate.hasKey(userEmail))) {
+      Cart cart = new Cart();
+      cart.setItems(new ArrayList<>());
+      redisTemplate.opsForValue().set(userEmail, serialize(cart));
+    }
+
+    String cartJson = (String) redisTemplate.opsForValue().get(userEmail);
+
+    Cart cart = deserialize(cartJson);
+
+    if (!cart.getItems().isEmpty()) {
+      if (!(cart.getItems().get(0)).getStoreId().equals(menu.getStoreId())) {
+        throw new RestApiException(DIFFERENT_STORE_IN_CART);
+      }
+    }
+
+    menu.setCartId((!cart.getItems().isEmpty() ? (cart.getItems().get(cart.getItems().size()-1)).getCartId() + 1 : 1));
+
+    addMenuToCart(cart, menu);
+
+    redisTemplate.opsForValue().set(userEmail, serialize(cart));
+
+    return getCart(userEmail);
+  }
+
+  private void addMenuToCart(Cart cart, CartDto menu) {
+    CartMenuDto menuDto = new CartMenuDto(menuRepository.findById(menu.getMenu().getMenuId())
+        .orElseThrow(() -> new RestApiException(MENU_NOT_FOUND)));
+
+    if (!cart.getItems().isEmpty()) {
+      if (menuDto.getStoreId() != cart.getItems().get(0)
+          .getStoreId()) {
+        throw new RestApiException(DIFFERENT_STORE_IN_CART);
+      }
+    }
+
+    menu.setMenu(menuDto);
+
+    List<AdditionalMenu> additionalMenuList = additionalMenuRepository
+        .findAllByAdditionalMenuIdIn(menu.getAdditionalMenuList().stream().map(AdditionalMenuDto::getAdditionalMenuId).toList());
+
+    menu.setAdditionalMenuList(additionalMenuList.stream().filter(item -> item.getMenu().getMenuId() == menuDto.getMenuId()).map(AdditionalMenuDto::new).toList());
+
+    menu.setTotalCost(menu.getQuantity() * (menu.getMenu().getPrice() + additionalMenuList.stream().mapToInt(
+        AdditionalMenu::getPrice).sum()));
+
+    cart.getItems().add(menu);
+  }
+
+  public List<CartDto> removeFromCart(String userEmail, String cartId) {
+    if (Boolean.FALSE.equals(redisTemplate.hasKey(userEmail))) {
+      throw new RestApiException(CART_IS_EMPTY);
+    }
+
+    Cart cart = deserialize((String) redisTemplate.opsForValue().get(userEmail));
+
+    removeMenuFromCart(cart, Long.parseLong(cartId));
+
+    redisTemplate.opsForValue().set(userEmail, serialize(cart));
+
+    return getCart(userEmail);
+  }
+
+  private void removeMenuFromCart(Cart cart, long cartId) {
+    List<CartDto> list = cart.getItems();
+    for(int i=0; i<list.size(); i++) {
+      if((list.get(i)).getCartId() == cartId) {
+        list.remove(i);
+        break;
+      }
+    }
+  }
+
+  public List<CartDto> updateCartMenu(String userEmail, String cartId, CartDto menuDto) {
+    if (Boolean.FALSE.equals(redisTemplate.hasKey(userEmail))) {
+      throw new RestApiException(CART_IS_EMPTY);
+    }
+    menuDto.setCartId(Long.parseLong(cartId));
+
+    Cart cart = deserialize((String) redisTemplate.opsForValue().get(userEmail));
+
+    updateCartMenu(cart, menuDto);
+
+    redisTemplate.opsForValue().set(userEmail, serialize(cart));
+
+    return getCart(userEmail);
+  }
+
+  private void updateCartMenu(Cart cart, CartDto menu) {
+    List<CartDto> list = cart.getItems();
+
+    List<AdditionalMenu> additionalMenuList = additionalMenuRepository
+        .findAllByAdditionalMenuIdIn(menu.getAdditionalMenuList().stream().map(AdditionalMenuDto::getAdditionalMenuId).toList());
+
+    list.stream().filter(item -> item.getCartId() == menu.getCartId()).findFirst().map(cartDto -> {
+      cartDto.setQuantity(menu.getQuantity());
+      cartDto.setAdditionalMenuList(additionalMenuList.stream().map(AdditionalMenuDto::new).toList());
+      cartDto.setTotalCost(menu.getQuantity() * (cartDto.getMenu().getPrice() + additionalMenuList.stream().mapToInt(AdditionalMenu::getPrice).sum()));
+      return cartDto;
+    }).orElseThrow(() -> new RestApiException(CART_NOT_FOUND));
+
+  }
+
+  private String serialize(Cart cart) {
+    try {
+      return new ObjectMapper().writeValueAsString(cart);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Error serializing cart", e);
+    }
+  }
+
+  private Cart deserialize(String json) {
+    try {
+      return new ObjectMapper().readValue(json, Cart.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Error deserializing cart", e);
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,14 +17,17 @@ spring:
   jwt:
     secret: c3ByaW5nLWJvb3QtcHJvamVjdC1kZWxpdmVyeS1zZXJ2aWNlLWp3dC1zZWNyZXQta2V5Cgbg
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     root: INFO
     com.younggeun.delivery: DEBUG
 
-redis:
-  host: localhost
-  port: 6379
+
 
 store:
   photo:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,14 +2,14 @@ spring:
   application:
     name: Delivery
 
+  profiles:
+    group:
+      logging: dev, log
+    active: dev
+
   config:
     import:
       - classpath:/yaml/application-dev.yml
-    profiles:
-      group:
-        logging: dev, log
-      active: logging
-
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,25 +2,14 @@ spring:
   application:
     name: Delivery
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/delivery
-    username: delivery
-    password: delivery
+  config:
+    import:
+      - classpath:/yaml/application-dev.yml
+    profiles:
+      group:
+        logging: dev, log
+      active: logging
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    defer-datasource-initialization: true
-
-  jwt:
-    secret: c3ByaW5nLWJvb3QtcHJvamVjdC1kZWxpdmVyeS1zZXJ2aWNlLWp3dC1zZWNyZXQta2V5Cgbg
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 logging:
   level:
@@ -29,14 +18,12 @@ logging:
 
 
 
-store:
-  photo:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/photo/files
-    baseUrlPath: /files
-  profile:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/profile/files
-    baseUrlPath: /files
-menu:
-  photo:
-    baseLocalPath: /Users/chldu/IdeaProjects/Delivery/store/menu/photo/files
-    baseUrlPath: /files
+
+
+#kakaopay:
+#  admin-key: 92308f2141a289808ff6fba12e4fc0b1
+#  dev-key: DEV4C6A9948C4A0FC29A998B38A62EEA2024EE6F
+#  cid: 76D16B528843874742CD
+#  ready-url-dev: https://open-api.kakaopay.com/online/v1/payment/ready
+#  approve-url-dev: https://open-api.kakaopay.com/online/v1/payment/approve
+#  cancel-url-dev: https://open-api.kakaopay.com/online/v1/payment/cancel

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,15 +15,3 @@ logging:
   level:
     root: INFO
     com.younggeun.delivery: DEBUG
-
-
-
-
-
-#kakaopay:
-#  admin-key: 92308f2141a289808ff6fba12e4fc0b1
-#  dev-key: DEV4C6A9948C4A0FC29A998B38A62EEA2024EE6F
-#  cid: 76D16B528843874742CD
-#  ready-url-dev: https://open-api.kakaopay.com/online/v1/payment/ready
-#  approve-url-dev: https://open-api.kakaopay.com/online/v1/payment/approve
-#  cancel-url-dev: https://open-api.kakaopay.com/online/v1/payment/cancel


### PR DESCRIPTION
### 변경사항
**AS-IS**
피드백 받은 내용을 수정하였습니다.

**TO-BE**
redis를 사용하여 user 장바구니 관련 CRUD 기능을 추가했습니다. 

같은 가게의 메뉴만 장바구니에 담을 수 있습니다.

카카오페이 api 연동 및 주문하기 기능 추가, partner 주문 관련 기능 추가했습니다.

### 테스트

- [ ] 테스트 코드
- [x] API 테스트 
